### PR TITLE
Fix outdated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,5 +211,6 @@ GigaAM's code and model weights are released under the [MIT License](./LICENSE).
 
 ## Links
 * [[habr] GigaAM: класс открытых моделей для обработки звучащей речи](https://habr.com/ru/companies/sberdevices/articles/805569)
+* [[youtube] Как научить LLM слышать: GigaAM 🤝 GigaChat Audio](https://www.youtube.com/watch?v=O7NSH2SAwRc)
 * [[youtube] GigaAM: Семейство акустических моделей для русского языка](https://youtu.be/PvZuTUnZa2Q?t=26442)
 * [[youtube] Speech-only Pre-training: обучение универсального аудиоэнкодера](https://www.youtube.com/watch?v=ktO4Mx6UMNk)

--- a/README_ru.md
+++ b/README_ru.md
@@ -200,5 +200,6 @@ print(", ".join([f"{emotion}: {prob:.3f}" for emotion, prob in emotion2prob.item
 
 ## Ссылки
 * [[habr] GigaAM: класс открытых моделей для обработки звучащей речи](https://habr.com/ru/companies/sberdevices/articles/805569)
+* [[youtube] Как научить LLM слышать: GigaAM 🤝 GigaChat Audio](https://www.youtube.com/watch?v=O7NSH2SAwRc)
 * [[youtube] GigaAM: Семейство акустических моделей для русского языка](https://youtu.be/PvZuTUnZa2Q?t=26442)
 * [[youtube] Speech-only Pre-training: обучение универсального аудиоэнкодера](https://www.youtube.com/watch?v=ktO4Mx6UMNk)

--- a/gigaam/__init__.py
+++ b/gigaam/__init__.py
@@ -13,7 +13,7 @@ from .utils import format_time
 # Default cache directory
 _CACHE_DIR = os.path.expanduser("~/.cache/gigaam")
 # Url with model checkpoints
-_URL_DIR = "https://n-ws-q0bez.s3pd12.sbercloud.ru/b-ws-q0bez-jpv/GigaAM"
+_URL_DIR = "https://cdn.chatwm.opensmodel.sberdevices.ru/GigaAM"
 _MODEL_NAMES = [
     "ctc",
     "rnnt",

--- a/inference_example.ipynb
+++ b/inference_example.ipynb
@@ -30,8 +30,8 @@
       "outputs": [],
       "source": [
         "# Downloading wavs for examples\n",
-        "!wget https://n-ws-q0bez.s3pd12.sbercloud.ru/b-ws-q0bez-jpv/GigaAM/example.wav\n",
-        "!wget https://n-ws-q0bez.s3pd12.sbercloud.ru/b-ws-q0bez-jpv/GigaAM/long_example.wav"
+        "!wget https://cdn.chatwm.opensmodel.sberdevices.ru/GigaAM/example.wav\n",
+        "!wget https://cdn.chatwm.opensmodel.sberdevices.ru/GigaAM/long_example.wav"
       ]
     },
     {


### PR DESCRIPTION
Fixed outdated links in `README.md`, `README_ru.md`, `gigaam/__init__.py` and `inference_example.ipynb`